### PR TITLE
Add ZLP stats to fit ZLP computation. Add calculate thickness computation.

### DIFF
--- a/nionswift_plugin/nion_eels_analysis/CalculateThickness.py
+++ b/nionswift_plugin/nion_eels_analysis/CalculateThickness.py
@@ -1,0 +1,115 @@
+# imports
+import gettext
+import numpy
+import typing
+
+# local libraries
+from nion.data import Core
+from nion.data import DataAndMetadata
+from nion.data import Calibration
+from nion.swift.model import DataStructure
+from nion.swift.model import Symbolic
+from nion.swift.model import Schema
+from nion.swift import Facade
+from nion.utils import Registry
+
+from nion.eels_analysis import ZLP_Analysis
+
+
+_ = gettext.gettext
+
+
+
+class CalculateThickness:
+    label = _("Calculate Thickness")
+    inputs = {
+        "eels_spectrum_data_item": {"label": _("EELS Spectrum")},
+        "zlp_model": {"label": _("Zero Loss Peak Model"), "entity_id": "zlp_model"},
+        }
+    outputs = {
+        "zlp_graphic": {"label": _("ZLP Graphic")},
+        "thickness_map": {"label": _("Thickness Map")}
+    }
+
+    def __init__(self, computation, **kwargs):
+        self.computation = computation
+        self.__thickness = None
+        self.__zlp_position = None
+        self.__eels_spectrum_data_item = None
+
+    def execute(self, eels_spectrum_data_item, zlp_model, **kwargs) -> None:
+        try:
+            spectrum_xdata = eels_spectrum_data_item.xdata
+            assert spectrum_xdata.is_datum_1d
+            assert spectrum_xdata.datum_dimensional_calibrations[0].units == "eV"
+            model_xdata = None
+            if zlp_model._data_structure.entity:
+                entity_id = zlp_model._data_structure.entity.entity_type.entity_id
+                for component in Registry.get_components_by_type("zlp-model"):
+                    # print(f"{entity_id=} {component.zero_loss_peak_model_id=}")
+                    if entity_id == component.zero_loss_peak_model_id:
+                        fit_result = component.fit_zero_loss_peak(spectrum_xdata=spectrum_xdata)
+                        model_xdata = fit_result["zero_loss_peak_model"]
+            if model_xdata is not None:
+                self.__thickness = numpy.log(numpy.sum(spectrum_xdata.data, axis=-1) / numpy.sum(model_xdata.data, axis=-1))
+                if numpy.ndim(self.__thickness) > 0:
+                    self.__zlp_position = None
+                    self.__thickness = DataAndMetadata.new_data_and_metadata(self.__thickness,
+                                                                             dimensional_calibrations=spectrum_xdata.dimensional_calibrations[:-1],
+                                                                             intensity_calibration = Calibration.Calibration(units="1/\N{GREEK SMALL LETTER LAMDA}"))
+                else:
+                    self.__zlp_position = numpy.argmax(model_xdata.data)
+            else:
+                self.__thickness = None
+                self.__zlp_position = None
+            self.__eels_spectrum_data_item = eels_spectrum_data_item
+        except Exception as e:
+            import traceback
+            print(traceback.format_exc())
+            print(e)
+            raise
+
+    def commit(self):
+        if self.__thickness is not None:
+            if self.__zlp_position is None:
+                self.computation.set_referenced_xdata("thickness_map", self.__thickness)
+            else:
+                zlp_graphic = self.computation.get_result("zlp_graphic", None)
+                data_length = self.__eels_spectrum_data_item.data.shape[-1]
+                if not zlp_graphic:
+                    zlp_graphic = self.__eels_spectrum_data_item.add_channel_region(self.__zlp_position / data_length)
+                    self.computation.set_result("zlp_graphic", zlp_graphic)
+                zlp_graphic.position = self.__zlp_position / data_length
+                zlp_graphic.graphic_id = "zlp_graphic"
+                zlp_graphic._graphic.color = "#0F0"
+                zlp_graphic.label = f"Sample thickness: {self.__thickness:.4g} 1/\N{GREEK SMALL LETTER LAMDA}"
+        else:
+            zlp_graphic = self.computation.get_result("zlp_graphic", None)
+            if zlp_graphic:
+                self.__eels_spectrum_data_item.remove_region(zlp_graphic)
+                self.computation.set_result("zlp_graphic", None)
+
+
+def measure_thickness(api: Facade.API_1, window: Facade.DocumentWindow) -> None:
+    target_data_item = window.target_data_item
+    if not target_data_item:
+        return
+
+    zlp_model = DataStructure.DataStructure(structure_type="simple_peak_model")
+    api.library._document_model.append_data_structure(zlp_model)
+    zlp_model.source = target_data_item._data_item
+    thickness_map_data_item = None
+    if target_data_item.xdata and target_data_item.xdata.is_navigable:
+        thickness_map_data_item = api.library.create_data_item(title=f"{target_data_item.title} thickness map")
+
+    api.library.create_computation("eels.calculate_thickness",
+                                   inputs={
+                                       "eels_spectrum_data_item": target_data_item,
+                                       "zlp_model": api._new_api_object(zlp_model),
+                                   },
+                                   outputs={
+                                       "zlp_graphic": None,
+                                       "thickness_map": thickness_map_data_item}
+                                   )
+
+Symbolic.register_computation_type("eels.calculate_thickness", CalculateThickness)

--- a/nionswift_plugin/nion_eels_analysis/__init__.py
+++ b/nionswift_plugin/nion_eels_analysis/__init__.py
@@ -12,6 +12,7 @@ from . import LiveThickness
 from . import LiveZLP
 from . import PeakFitting
 from . import ThicknessMap
+from . import CalculateThickness
 
 from nion.swift import Facade
 
@@ -53,5 +54,6 @@ class MenuExtension:
         eels_menu.add_separator()
         eels_menu.add_menu_item(_("Show Live Thickness Measurement"), functools.partial(LiveThickness.attach_measure_thickness, api, window))
         eels_menu.add_menu_item(_("Show Live ZLP Measurement"), functools.partial(LiveZLP.attach_measure_zlp, api, window))
+        eels_menu.add_menu_item(_("Calculate Thickness"), functools.partial(CalculateThickness.measure_thickness, api, window))
         eels_menu.add_separator()
         eels_menu.add_menu_item(_("Calibrate Spectrum"), functools.partial(AlignZLP.calibrate_spectrum, api, window))

--- a/nionswift_plugin/nion_eels_analysis/test/CalculateThickness_test.py
+++ b/nionswift_plugin/nion_eels_analysis/test/CalculateThickness_test.py
@@ -1,0 +1,103 @@
+import numpy
+import unittest
+
+from nion.data import Calibration
+from nion.data import DataAndMetadata
+from nion.swift import Application
+from nion.swift import Facade
+from nion.swift.model import DataItem
+import time
+
+from nion.swift.test import TestContext
+from nion.ui import TestUI
+
+from nionswift_plugin.nion_eels_analysis import CalculateThickness
+
+
+Facade.initialize()
+
+
+class TestCalculateThickness(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def __run_until_complete(self, document_controller):
+        # run for 0.2s; recomputing and running periodic
+        for _ in range(10):
+            document_controller.document_model.recompute_all()
+            document_controller.periodic()
+            time.sleep(1/50)
+
+    def test_calculate_thickness_for_single_spectrum(self):
+        with TestContext.create_memory_context() as profile_context:
+            document_controller = profile_context.create_document_controller_with_application()
+            document_model = document_controller.document_model
+            data = numpy.ones((100,), dtype=numpy.float32)
+            data[10] = 100
+            intensity_calibration = Calibration.Calibration(units="~")
+            dimensional_calibrations = [Calibration.Calibration(offset= -10.0, scale=1.0, units="eV")]
+            data_descriptor = DataAndMetadata.DataDescriptor(is_sequence=False, collection_dimension_count=0, datum_dimension_count=1)
+            xdata = DataAndMetadata.new_data_and_metadata(data, intensity_calibration=intensity_calibration, dimensional_calibrations=dimensional_calibrations, data_descriptor=data_descriptor)
+            data_item = DataItem.new_data_item(xdata)
+            document_model.append_data_item(data_item)
+            display_item = document_model.get_display_item_for_data_item(data_item)
+            document_controller.select_display_items_in_data_panel([display_item])
+            document_controller.data_panel_focused()
+            api = Facade.get_api("~1.0", "~1.0")
+            CalculateThickness.measure_thickness(api, api.application.document_windows[0])
+            self.__run_until_complete(document_controller)
+            self.assertEqual(1, len(document_model.data_items))
+            self.assertEqual(1, len(document_model.display_items))
+            self.assertEqual(1, len(api.library.data_items))
+            # measure_thickness should create one graphic
+            self.assertEqual(1, len(api.library.data_items[0].graphics))
+            # It should find the peak at 10 and put the graphic there
+            self.assertAlmostEqual(api.library.data_items[0].graphics[0].position, 0.1)
+            # Check that the correct thickness is shown in the label
+            label = api.library.data_items[0].graphics[0].label
+            thickness = float(label.split()[2])
+            self.assertAlmostEqual(numpy.log(numpy.sum(data)/numpy.amax(data)), thickness, places=1)
+            # Test cleanup
+            document_model.remove_data_item(data_item)
+            self.assertEqual(0, len(document_model.data_items))
+            self.assertEqual(0, len(document_model.display_items))
+            self.assertEqual(0, len(document_model.data_structures))
+
+    def test_calculate_thickness_for_spectrum_image(self):
+        with TestContext.create_memory_context() as profile_context:
+            document_controller = profile_context.create_document_controller_with_application()
+            document_model = document_controller.document_model
+            data = numpy.ones((4, 3, 100), dtype=numpy.float32)
+            data[..., 10] = 100
+            intensity_calibration = Calibration.Calibration(units="~")
+            dimensional_calibrations = [Calibration.Calibration(), Calibration.Calibration(), Calibration.Calibration(offset= -10.0, scale=1.0, units="eV")]
+            data_descriptor = DataAndMetadata.DataDescriptor(is_sequence=False, collection_dimension_count=2, datum_dimension_count=1)
+            xdata = DataAndMetadata.new_data_and_metadata(data, intensity_calibration=intensity_calibration, dimensional_calibrations=dimensional_calibrations, data_descriptor=data_descriptor)
+            data_item = DataItem.new_data_item(xdata)
+            document_model.append_data_item(data_item)
+            display_item = document_model.get_display_item_for_data_item(data_item)
+            document_controller.select_display_items_in_data_panel([display_item])
+            document_controller.data_panel_focused()
+            api = Facade.get_api("~1.0", "~1.0")
+            CalculateThickness.measure_thickness(api, api.application.document_windows[0])
+            self.__run_until_complete(document_controller)
+            # measure_thickness should create a data item (the thickness map)
+            self.assertEqual(2, len(document_model.data_items))
+            self.assertEqual(2, len(document_model.display_items))
+            self.assertEqual(2, len(api.library.data_items))
+            # measure_thickness should not create any graphics
+            self.assertEqual(0, len(api.library.data_items[0].graphics))
+            result_data_item = api.library.data_items[1]
+            # Check that the thickness map has the correct shape
+            self.assertSequenceEqual(data.shape[:-1], result_data_item.data.shape)
+            # Check that the correct thickness is shown in the thickness map
+            self.assertTrue(numpy.allclose(result_data_item.data, numpy.log(numpy.sum(data, axis=-1)/numpy.amax(data, axis=-1)), atol=0.1))
+            # Test cleanup
+            document_model.remove_data_item(data_item)
+            self.assertEqual(0, len(document_model.data_items))
+            self.assertEqual(0, len(document_model.display_items))
+            self.assertEqual(0, len(document_model.data_structures))


### PR DESCRIPTION
I finally managed to add the computations we discussed.
I also made a small change to the fit ZLP computation: It shows the ZLP stats (position, FWHM) in an annotation now.
But the main change is a "Calculate Thickness" computation that uses the ZLP models registered in the "Fit ZLP" computation. I also added tests so we should be able to used this as a template for similar computations now.
"CalculateThickness" also works for single spectra, live spectra and spectrum images so it should be able to supersede "Live THickness" and "Tickness Map" eventually.

I'm not sure that the way I'm calculating the thickness is the best, though: I'm using the modeled ZLP and the real data to calculate the thickness, so the result will be highly dependant on which ZLP model the user selects. But that would be an easy change.